### PR TITLE
pinning jpegtran version to one known to work with Heroku

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ indent() {
 echo "-----> Installing jpegtran"
 BUILD_DIR=$1
 VENDOR_DIR="vendor"
-OPTIPNG_DOWNLOAD_URL="https://github.com/yeoman/node-jpegtran-bin/raw/master/vendor/linux/x64/jpegtran"
+OPTIPNG_DOWNLOAD_URL="https://github.com/yeoman/node-jpegtran-bin/raw/018416e617c91730c6ebceca6d203b2424d20f41/vendor/linux/x64/jpegtran"
 
 echo "OPTIPNG_DOWNLOAD_URL = " $OPTIPNG_DOWNLOAD_URL | indent
 


### PR DESCRIPTION
The jpegtran version referenced in the original URL was changed a few days ago to one requiring GLIBC 2.14, which Heroku doesn't have yet. I've pinned the version of jpegtran that is imported to the one before, which only requires GLIBC 2.11 and thus works on Heroku.
